### PR TITLE
Turn the screen off and on on start

### DIFF
--- a/src/screensaver.ts
+++ b/src/screensaver.ts
@@ -24,6 +24,10 @@ export async function screenOff(): Promise<void> {
 	await execFile('xset', 'dpms', 'force', 'off');
 }
 
+async function screenOn(): Promise<void> {
+	await execFile('xset', 'dpms', 'force', 'on');
+}
+
 let screensaverDisabled = false;
 
 async function setSleepDelay(value?: string): Promise<void> {
@@ -81,6 +85,12 @@ async function setScreensaverHooks(): Promise<void> {
 }
 
 export async function init(): Promise<void> {
+	// When the container is restarted when the screen was off,
+	// we need to turn the screen off and on again to make it work.
+	// screenOn() without screenOff() before has no effect.
+	// We need to do this before setScreensaverHooks().
+	await screenOff();
+	await screenOn();
 	electron.ipcMain.handle('disable-screensaver', async () => {
 		debug('disabling screensaver');
 		await setSleepDelay('never');


### PR DESCRIPTION
This prevents a bug where the screen stays blank after a container
restart

Change-type: patch